### PR TITLE
STEP11/12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ replay_pid*
 
 # grafana
 grafana/
+
+# redis
+redis_data/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
 ```bash
 docker-compose up -d
 ```
+
+```
+docker-compose -f ./docker-compose-redis.yml up -d
+```
+
 ---
+## 동시성 제어 기법(Lock) 비교 분석 및 구현
+### [동시성 제어 기법(Lock) 비교 분석 및 구현](https://github.com/han-chunsik/hhplus-service/wiki/%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%A0%9C%EC%96%B4-%EA%B8%B0%EB%B2%95(Lock)-%EB%B9%84%EA%B5%90-%EB%B6%84%EC%84%9D-%EB%B0%8F-%EA%B5%AC%ED%98%84)
+
 ## Week-01: 요구사항 분석 및 설계
 ### [1. Milestone](https://github.com/han-chunsik/hhplus-service/wiki/%EC%84%A4%EA%B3%84-%7C-%EB%A7%88%EC%9D%BC%EC%8A%A4%ED%86%A4)
 ### [2. 요구사항 정의 및 설계](https://github.com/han-chunsik/hhplus-service/wiki/%EC%84%A4%EA%B3%84-%7C-%EC%9A%94%EA%B5%AC%EC%82%AC%ED%95%AD-%EC%A0%95%EC%9D%98-%EB%B0%8F-%EC%84%A4%EA%B3%84)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 
+	// redis
+	implementation("org.redisson:redisson-spring-boot-starter:3.27.0")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,15 @@
+services:
+  redis:
+    image: docker.io/bitnami/redis:7.4
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - '6379:6379'
+    volumes:
+      - ./redis_data:/bitnami/redis/data
+
+volumes:
+  redis_data:
+    driver: local

--- a/k6/test.js
+++ b/k6/test.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    vus: 100, // 가상 사용자 수
+    duration: '30s', // 테스트 지속 시간
+};
+
+export default function () {
+    const userId = `${__VU}`; // __VU는 현재 가상 사용자 번호
+    const seatId = '107'; // 좌석 ID
+
+    // 예약 요청을 보냄
+    const url = `http://host.docker.internal:8080/api/v1/reservation/temporary`;
+    const payload = JSON.stringify({
+        seatId: seatId,
+        userId: userId,
+    });
+
+    const reservationResponse = http.post(url, payload, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `test`, // 발급받은 토큰을 헤더에 포함
+        },
+    });
+
+    check(reservationResponse, {
+        '예약 요청 성공': (r) => r.status === 200,
+    });
+}

--- a/src/main/java/kr/hhplus/be/server/balance/domain/repository/BalanceRepository.java
+++ b/src/main/java/kr/hhplus/be/server/balance/domain/repository/BalanceRepository.java
@@ -1,9 +1,7 @@
 package kr.hhplus.be.server.balance.domain.repository;
 
-import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.balance.domain.model.Balance;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface BalanceRepository extends JpaRepository<Balance, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //@Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT b FROM Balance b WHERE b.userId = :userId")
     Optional<Balance> findFirstByUserIdWithLock(@Param("userId") Long userId);
 

--- a/src/main/java/kr/hhplus/be/server/balance/domain/service/BalanceService.java
+++ b/src/main/java/kr/hhplus/be/server/balance/domain/service/BalanceService.java
@@ -8,6 +8,7 @@ import kr.hhplus.be.server.balance.domain.repository.BalanceHistoryRepository;
 import kr.hhplus.be.server.balance.domain.repository.BalanceRepository;
 import kr.hhplus.be.server.balance.exception.BalanceErrorCode;
 import kr.hhplus.be.server.balance.exception.BalanceException;
+import kr.hhplus.be.server.common.aop.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class BalanceService {
     private final BalanceRepository balanceRepository;
     private final BalanceHistoryRepository balanceHistoryRepository;
 
+    @DistributedLock(key = "'balance:' + #userId", lockType = DistributedLock.LockType.FAIR)
     @Transactional
     public BalanceChargeResult chargeBalance(long userId, long amount) {
         // 1. 사용자 잔액 조회
@@ -42,6 +44,7 @@ public class BalanceService {
         return BalanceResult.from(userBalance);
     }
 
+    @DistributedLock(key = "'balance:' + #userId", lockType = DistributedLock.LockType.FAIR)
     @Transactional
     public BalanceChargeResult useBalance(long userId, long amount) {
         // 1. 사용자 잔액 조회

--- a/src/main/java/kr/hhplus/be/server/common/aop/AopForTransaction.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/AopForTransaction.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
@@ -33,10 +33,12 @@ public class DistributedLockAop {
         long waitTime = distributedLock.waitTime();
         long leaseTime = distributedLock.leaseTime();
 
-        RLock lock;
+        RLock lock = null;
         if (distributedLock.lockType() == DistributedLock.LockType.NORMAL) {
             lock = redissonClient.getLock(lockKey);
-        } else {
+        }
+
+        if (distributedLock.lockType() == DistributedLock.LockType.FAIR){
             lock = redissonClient.getFairLock(lockKey);
         }
 
@@ -46,7 +48,8 @@ public class DistributedLockAop {
         }
 
         try {
-            return aopForTransaction.proceed(joinPoint);
+            // return aopForTransaction.proceed(joinPoint);
+            return joinPoint.proceed();
         } finally {
             if (lock.isLocked() && lock.isHeldByCurrentThread()) {
                 lock.unlock();

--- a/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/DistributedLockAop.java
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.common.aop;
+
+import kr.hhplus.be.server.common.aop.lock.DistributedLock;
+import kr.hhplus.be.server.common.aop.lock.DistributedLockKeyParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+
+    private final RedissonClient redissonClient;
+    private final DistributedLockKeyParser lockKeyParser;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(distributedLock)")
+    public Object handleDistributedLock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String lockKey = lockKeyParser.parseLockKey(joinPoint, distributedLock.key());
+        TimeUnit timeUnit = distributedLock.timeUnit();
+        long waitTime = distributedLock.waitTime();
+        long leaseTime = distributedLock.leaseTime();
+
+        RLock lock;
+        if (distributedLock.lockType() == DistributedLock.LockType.NORMAL) {
+            lock = redissonClient.getLock(lockKey);
+        } else {
+            lock = redissonClient.getFairLock(lockKey);
+        }
+
+        boolean isLocked = lock.tryLock(waitTime, leaseTime, timeUnit);
+        if (!isLocked) {
+            throw new IllegalStateException("현재 작업 중이므로 요청을 처리할 수 없습니다.");
+        }
+
+        try {
+            return aopForTransaction.proceed(joinPoint);
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/lock/DistributedLock.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.common.aop.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+
+    /**
+     * 락의 타입 (default - NORMAL)
+     * FAIR: getFairLock
+     * NORMAL: getLock
+     */
+    LockType lockType() default LockType.NORMAL;
+
+    enum LockType {
+        FAIR,
+        NORMAL
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/aop/lock/DistributedLockKeyParser.java
+++ b/src/main/java/kr/hhplus/be/server/common/aop/lock/DistributedLockKeyParser.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.common.aop.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.context.expression.MethodBasedEvaluationContext;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Component
+public class DistributedLockKeyParser {
+
+    private final ExpressionParser parser = new SpelExpressionParser();
+    private final DefaultParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
+
+    public String parseLockKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        Object[] args = joinPoint.getArgs();
+
+        EvaluationContext context = new MethodBasedEvaluationContext(
+                null, // root 객체 (필요하지 않음)
+                method,
+                args,
+                parameterNameDiscoverer
+        );
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/concert/domain/repository/ConcertSeatRepository.java
+++ b/src/main/java/kr/hhplus/be/server/concert/domain/repository/ConcertSeatRepository.java
@@ -1,9 +1,7 @@
 package kr.hhplus.be.server.concert.domain.repository;
 
-import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.concert.domain.model.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -13,7 +11,6 @@ import java.util.Optional;
 @Repository
 public interface ConcertSeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findSeatsByConcertScheduleIdAndStatus(Long concertScheduleId, Seat.Status status);
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Seat s WHERE s.id = :id")
-    Optional<Seat> findSeatByIdWithLock(Long id);
+    Optional<Seat> findSeatById(Long id);
 }

--- a/src/main/java/kr/hhplus/be/server/config/redisson/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redisson/RedissonConfig.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.config.redisson;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,9 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+---
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -9,6 +10,7 @@ import org.testcontainers.utility.DockerImageName;
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -21,12 +23,27 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
-	}
+
+	REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("bitnami/redis:7.4"))
+			.withExposedPorts(6379)
+			.withEnv("ALLOW_EMPTY_PASSWORD", "yes")
+			.withEnv("REDIS_DISABLE_COMMANDS", "FLUSHDB,FLUSHALL");
+        REDIS_CONTAINER.start();
+
+
+	String redisHost = REDIS_CONTAINER.getHost();
+	Integer redisPort = REDIS_CONTAINER.getFirstMappedPort();
+        System.setProperty("spring.data.redis.host", redisHost);
+        System.setProperty("spring.data.redis.port", redisPort.toString());
+}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/reservation/ReservationIntegration100UserTest.java
+++ b/src/test/java/kr/hhplus/be/server/reservation/ReservationIntegration100UserTest.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.server.reservation;
 
 import kr.hhplus.be.server.reservation.application.ReservationTemporary;
-import kr.hhplus.be.server.reservation.domain.repository.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,9 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ReservationIntegration100UserTest {
     @Autowired
     private ReservationTemporary reservationTemporary;
-
-    @Autowired
-    private ReservationRepository reservationRepository;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/kr/hhplus/be/server/reservation/ReservationIntegrationOneSeatTest.java
+++ b/src/test/java/kr/hhplus/be/server/reservation/ReservationIntegrationOneSeatTest.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.server.reservation;
 
 import kr.hhplus.be.server.reservation.application.ReservationTemporary;
-import kr.hhplus.be.server.reservation.domain.repository.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,9 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ReservationIntegrationOneSeatTest {
     @Autowired
     private ReservationTemporary reservationTemporary;
-
-    @Autowired
-    private ReservationRepository reservationRepository;
 
     @Nested
     @DisplayName("동시성 제어 통합 테스트")


### PR DESCRIPTION
### **커밋 링크**

**STEP 11_기본**      
- [동시성 제어 기법(Lock) 비교 분석 및 구현](https://github.com/han-chunsik/hhplus-service/wiki/%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%A0%9C%EC%96%B4-%EA%B8%B0%EB%B2%95(Lock)-%EB%B9%84%EA%B5%90-%EB%B6%84%EC%84%9D-%EB%B0%8F-%EA%B5%AC%ED%98%84)  

**STEP 12_심화**     
- ✅ 분산락: bb753f6872ed49f0472d454a02b5bae082355e52
- 비관적락: [기존에 구현](https://github.com/han-chunsik/hhplus-service/tree/pessimistic_lock)
- 낙관적락: 30ece967c0204b67da801af7e56589f748880eca 

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1 : 처음 분산락을 구성할때에는 동시성 제어를 하면서 트랜잭션에 들어가는 부하를 방지할 수 있을거라 생각했는데, 트랜잭션까지 접근하지 못하도록 하려면 락을 가지고 있는 시간을 길게 잡아두어야 하더라구요.. 이 경우 비효율적이라고 판단되어, 분산락 적용 시 기존에 적용했던 락을 모두 제거했는데 실무에서 보통 락을 중첩해서 사용하는 경우도 있을까요?
- 리뷰 포인트 2 : 분산락 관련 내용들을 common 패키지에 추가해두었는데, 보통 AOP같은 경우 어떤 패키지에서 관리되나요? filtter 처럼 따로 뺴는게 더 좋을까요?  
- 리뷰 포인트 3 : 참고하면 좋은 예시로 컬리에서 분산락을 사용하는 방법에 대해서 공유주셔서 (~따라했는데~)보았는데 트랜잭션 이후 락해제를 위해서 트랜잭션 전파 설정을 별도로 하는 부분이 있더라구요. 저의 경우 각 도메인 서비스에 @Transactional 을 설정하고, 해당 메서드를 호출하는 클래스에는 @Transactional 어노테이션을 설정하지 않은 구조로 구성되어있어서 이 경우 전파 가능성이 없지 않나.. 라고 생각되는데 맞을까요?
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->   
- 그래도 비교적 전보다는 깊게 파려고 노력하는 모습

### Problem
<!--개선이 필요한 점-->   
- 앵무새가 놀아달라고 날아오면 못참고 자꾸 노는 모습

### Try
<!-- 새롭게 시도할 점 -->   
- 동시성 제어를 구현한 라이브러리의 구조를 파악해보기